### PR TITLE
Add auto-rec calls links

### DIFF
--- a/shortlinks.csv
+++ b/shortlinks.csv
@@ -72,7 +72,8 @@ scrum-reminder-howto,https://docs.google.com/document/d/1Vt_fPhcZMaJMU7S0p4LAG3-
 reminder-howto,http://go.talent.c4nada.ca/howto-reminder
 scrum-notes,https://docs.google.com/document/d/1AZYLj_SXILRK7TrmLQiDRQxGbkeoIm3I7JjToXkXyNU/edit
 sprint-notes,http://go.talent.c4nada.ca/scrum-notes
-calls,https://bit.ly/patcon-talent-scrum-calls
+calls,https://bit.ly/patcon-nonrec-calls
+autorec-calls,https://bit.ly/patcon-autorec-calls
 scrum-calls,http://go.talent.c4nada.ca/calls
 sprint-calls,http://go.talent.c4nada.ca/calls
 sprint-standup,http://go.talent.c4nada.ca/calls


### PR DESCRIPTION
This will:

- create a new shortlink for /autorec-calls that points to a zoom meeting (set falsely in Jan 1 2024) that will auto-record full session to the cloud on entry
- update the /calls shortlink to point to a new non-recorded zoom meeting (set falsely again to Jan 1, 2024), that will NOT auto-record. This is the new default, replacing the link to the accounts personal room, which cannot be configured as robustly.